### PR TITLE
Fix log level and divide by zero bug

### DIFF
--- a/cmd/drone-swarm/reporting/logger.go
+++ b/cmd/drone-swarm/reporting/logger.go
@@ -398,29 +398,23 @@ func (sl *SimulationLogger) logEvent(event SimulationEvent) {
 
 // logColoredMessage logs a message with color based on severity
 func (sl *SimulationLogger) logColoredMessage(severity, eventType, message string) {
-	timestamp := time.Now().Format("15:04:05.000")
+	// Use the global logger instead of direct fmt.Printf to respect log levels
+	logMessage := fmt.Sprintf("%s | %s", eventType, message)
 
-	var severityColor *color.Color
 	switch severity {
 	case SeverityDebug:
-		severityColor = colorDebug
+		logger.Debug(logMessage)
 	case SeverityInfo:
-		severityColor = colorInfo
+		logger.Info(logMessage)
 	case SeverityWarning:
-		severityColor = colorWarning
+		logger.Warn(logMessage)
 	case SeverityError:
-		severityColor = colorError
+		logger.Error(logMessage)
 	case SeverityCritical:
-		severityColor = colorCritical
+		logger.Error(logMessage) // Map critical to error level
 	default:
-		severityColor = colorInfo
+		logger.Info(logMessage)
 	}
-
-	fmt.Printf("[%s] %s %s | %s\n",
-		timestamp,
-		severityColor.Sprint(fmt.Sprintf("%-8s", severity)),
-		eventType,
-		message)
 }
 
 // getTeamColor returns the color for a team

--- a/cmd/drone-swarm/simulation/simulation.go
+++ b/cmd/drone-swarm/simulation/simulation.go
@@ -1314,8 +1314,12 @@ func (s *DroneSwarmSimulation) engageTarget(system *CounterUASSystem, target *UA
 		system.AmmoRemaining--
 	}
 
-	// Set cooldown based on reload time
-	cooldownTicks := system.ReloadTimeSeconds / int(s.config.UpdateInterval.Seconds())
+	// Set cooldown based on reload time - protect against divide by zero
+	updateIntervalSeconds := int(s.config.UpdateInterval.Seconds())
+	if updateIntervalSeconds < 1 {
+		updateIntervalSeconds = 1 // Minimum 1 second for safety
+	}
+	cooldownTicks := system.ReloadTimeSeconds / updateIntervalSeconds
 	if cooldownTicks < 1 {
 		cooldownTicks = 1
 	}

--- a/cmd/drone-swarm/simulation/simulation.go
+++ b/cmd/drone-swarm/simulation/simulation.go
@@ -192,6 +192,12 @@ func (s *DroneSwarmSimulation) Configure(params map[string]interface{}) error {
 		s.config.CleanupExisting = val
 	}
 
+	// Handle log level parameter and apply to global logger
+	if val, ok := params["log_level"].(string); ok {
+		logger.Infof("Setting log level to: %s", val)
+		logger.SetLevel(logger.ParseLevel(val))
+	}
+
 	// Validate configuration
 	if s.config.NumCounterUASSystems < 1 {
 		return fmt.Errorf("must have at least 1 Counter-UAS system")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix logging to respect log levels and prevent divide by zero in `engageTarget()` in `simulation.go`.
> 
>   - **Logging**:
>     - Use global logger in `logColoredMessage()` in `logger.go` to respect log levels.
>     - Map `SeverityCritical` to error level in `logger.go`.
>   - **Configuration**:
>     - Handle `log_level` parameter in `Configure()` in `simulation.go` to set global logger level.
>   - **Bug Fix**:
>     - Prevent divide by zero in `engageTarget()` in `simulation.go` by ensuring `updateIntervalSeconds` is at least 1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=picogrid%2Flegion-simulations&utm_source=github&utm_medium=referral)<sup> for 71dc6c2ba93d53346b20231b1ae76691137ce558. You can [customize](https://app.ellipsis.dev/picogrid/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->