### PR TITLE
feat: add track traffic simulation

### DIFF
--- a/cmd/cli/cmd/run.go
+++ b/cmd/cli/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/picogrid/legion-simulations/cmd/drone-swarm/simulation"
 	_ "github.com/picogrid/legion-simulations/cmd/drone-tornado"
 	_ "github.com/picogrid/legion-simulations/cmd/simple"
+	_ "github.com/picogrid/legion-simulations/cmd/track-traffic"
 )
 
 var runCmd = &cobra.Command{

--- a/cmd/track-traffic/config.go
+++ b/cmd/track-traffic/config.go
@@ -1,0 +1,213 @@
+package tracktraffic
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config holds the configuration for the track traffic simulation.
+type Config struct {
+	TotalTracks     int
+	MaxConcurrency  int
+	UpdateInterval  time.Duration
+	Duration        time.Duration
+	CenterLat       float64
+	CenterLon       float64
+	CenterAltMeters float64
+	GridSpacingM    float64
+	GridJitterM     float64
+	HistoryPoints   int
+	HistoryStep     time.Duration
+	DeleteOnExit    bool
+	OrganizationID  string
+}
+
+// ValidateAndParse validates and parses raw parameters into a Config.
+func ValidateAndParse(params map[string]interface{}) (*Config, error) {
+	cfg := &Config{
+		DeleteOnExit: true,
+	}
+
+	if v, ok := params["total_tracks"]; ok {
+		switch val := v.(type) {
+		case int:
+			cfg.TotalTracks = val
+		case float64:
+			cfg.TotalTracks = int(val)
+		default:
+			return nil, fmt.Errorf("total_tracks must be an integer")
+		}
+	}
+	if cfg.TotalTracks < 1 {
+		return nil, fmt.Errorf("total_tracks must be at least 1")
+	}
+
+	if v, ok := params["max_concurrency"]; ok {
+		switch val := v.(type) {
+		case int:
+			cfg.MaxConcurrency = val
+		case float64:
+			cfg.MaxConcurrency = int(val)
+		default:
+			return nil, fmt.Errorf("max_concurrency must be an integer")
+		}
+	}
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = minInt(maxInt(cfg.TotalTracks/10, 8), 64)
+	}
+	if cfg.MaxConcurrency > cfg.TotalTracks {
+		cfg.MaxConcurrency = cfg.TotalTracks
+	}
+
+	if v, ok := params["update_interval"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.UpdateInterval = time.Duration(val * float64(time.Second))
+		case int:
+			cfg.UpdateInterval = time.Duration(val) * time.Second
+		default:
+			return nil, fmt.Errorf("update_interval must be a number (seconds)")
+		}
+	}
+	if cfg.UpdateInterval < time.Second {
+		return nil, fmt.Errorf("update_interval must be at least 1 second")
+	}
+
+	if v, ok := params["duration"]; ok {
+		durationStr := fmt.Sprintf("%v", v)
+		duration, err := time.ParseDuration(durationStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration format: %w", err)
+		}
+		cfg.Duration = duration
+	}
+	if cfg.Duration <= 0 {
+		return nil, fmt.Errorf("duration must be greater than 0")
+	}
+
+	if v, ok := params["center_lat"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.CenterLat = val
+		case int:
+			cfg.CenterLat = float64(val)
+		default:
+			return nil, fmt.Errorf("center_lat must be a number")
+		}
+	}
+
+	if v, ok := params["center_lon"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.CenterLon = val
+		case int:
+			cfg.CenterLon = float64(val)
+		default:
+			return nil, fmt.Errorf("center_lon must be a number")
+		}
+	}
+
+	if v, ok := params["center_alt_m"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.CenterAltMeters = val
+		case int:
+			cfg.CenterAltMeters = float64(val)
+		default:
+			return nil, fmt.Errorf("center_alt_m must be a number (meters)")
+		}
+	}
+
+	if v, ok := params["grid_spacing_m"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.GridSpacingM = val
+		case int:
+			cfg.GridSpacingM = float64(val)
+		default:
+			return nil, fmt.Errorf("grid_spacing_m must be a number (meters)")
+		}
+	}
+	if cfg.GridSpacingM < 100 {
+		return nil, fmt.Errorf("grid_spacing_m must be at least 100 meters")
+	}
+
+	if v, ok := params["grid_jitter_m"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.GridJitterM = val
+		case int:
+			cfg.GridJitterM = float64(val)
+		default:
+			return nil, fmt.Errorf("grid_jitter_m must be a number (meters)")
+		}
+	}
+	if cfg.GridJitterM < 0 {
+		return nil, fmt.Errorf("grid_jitter_m must be greater than or equal to 0")
+	}
+	if cfg.GridJitterM > cfg.GridSpacingM*0.35 {
+		return nil, fmt.Errorf("grid_jitter_m must be no more than 35%% of grid_spacing_m to keep tracks separated")
+	}
+
+	if v, ok := params["history_points"]; ok {
+		switch val := v.(type) {
+		case int:
+			cfg.HistoryPoints = val
+		case float64:
+			cfg.HistoryPoints = int(val)
+		default:
+			return nil, fmt.Errorf("history_points must be an integer")
+		}
+	}
+	if cfg.HistoryPoints < 2 {
+		return nil, fmt.Errorf("history_points must be at least 2")
+	}
+
+	if v, ok := params["history_step_seconds"]; ok {
+		switch val := v.(type) {
+		case float64:
+			cfg.HistoryStep = time.Duration(val * float64(time.Second))
+		case int:
+			cfg.HistoryStep = time.Duration(val) * time.Second
+		default:
+			return nil, fmt.Errorf("history_step_seconds must be a number (seconds)")
+		}
+	}
+	if cfg.HistoryStep < time.Second {
+		return nil, fmt.Errorf("history_step_seconds must be at least 1 second")
+	}
+
+	if v, ok := params["delete_on_exit"]; ok {
+		switch val := v.(type) {
+		case bool:
+			cfg.DeleteOnExit = val
+		case string:
+			cfg.DeleteOnExit = val == "true" || val == "1" || val == "yes"
+		default:
+			return nil, fmt.Errorf("delete_on_exit must be a boolean")
+		}
+	}
+
+	if v, ok := params["organization_id"]; ok {
+		cfg.OrganizationID = fmt.Sprintf("%v", v)
+	}
+	if cfg.OrganizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+
+	return cfg, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/track-traffic/config_test.go
+++ b/cmd/track-traffic/config_test.go
@@ -1,0 +1,42 @@
+package tracktraffic
+
+import "testing"
+
+func TestValidateAndParse(t *testing.T) {
+	params := map[string]interface{}{
+		"total_tracks":         42,
+		"max_concurrency":      16,
+		"update_interval":      2.0,
+		"duration":             "5m",
+		"center_lat":           37.7749,
+		"center_lon":           -122.4194,
+		"center_alt_m":         0.0,
+		"grid_spacing_m":       700.0,
+		"grid_jitter_m":        80.0,
+		"history_points":       36,
+		"history_step_seconds": 5.0,
+		"delete_on_exit":       true,
+		"organization_id":      "ecc2dce2-b664-4077-b34c-ea89e1fb045e",
+	}
+
+	cfg, err := ValidateAndParse(params)
+	if err != nil {
+		t.Fatalf("ValidateAndParse returned error: %v", err)
+	}
+
+	if cfg.TotalTracks != 42 {
+		t.Fatalf("expected total_tracks=42, got %d", cfg.TotalTracks)
+	}
+	if cfg.MaxConcurrency != 16 {
+		t.Fatalf("expected max_concurrency=16, got %d", cfg.MaxConcurrency)
+	}
+	if cfg.HistoryPoints != 36 {
+		t.Fatalf("expected history_points=36, got %d", cfg.HistoryPoints)
+	}
+	if cfg.OrganizationID == "" {
+		t.Fatal("expected organization ID to be set")
+	}
+	if !cfg.DeleteOnExit {
+		t.Fatal("expected delete_on_exit=true")
+	}
+}

--- a/cmd/track-traffic/simulation.go
+++ b/cmd/track-traffic/simulation.go
@@ -1,0 +1,650 @@
+package tracktraffic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/picogrid/legion-simulations/pkg/client"
+	"github.com/picogrid/legion-simulations/pkg/logger"
+	"github.com/picogrid/legion-simulations/pkg/models"
+	"github.com/picogrid/legion-simulations/pkg/simulation"
+)
+
+type routePattern string
+
+const (
+	routeCircle    routePattern = "circle"
+	routeEllipse   routePattern = "ellipse"
+	routeFigure8   routePattern = "figure8"
+	routeLissajous routePattern = "lissajous"
+	routeWalker    routePattern = "walker"
+	routeJitter    routePattern = "jitter"
+)
+
+type trafficTrackSpec struct {
+	Name            string
+	Type            string
+	Status          string
+	Affiliation     models.Affiliation
+	Source          string
+	Pattern         routePattern
+	SpeedMetersPerS float64
+	AnchorNorthM    float64
+	AnchorEastM     float64
+	RadiusNorthM    float64
+	RadiusEastM     float64
+	BaseAltitudeM   float64
+	Metadata        map[string]interface{}
+}
+
+type trackTemplate struct {
+	NamePrefix      string
+	Type            string
+	Status          string
+	Affiliation     models.Affiliation
+	Source          string
+	Pattern         routePattern
+	SpeedMetersPerS float64
+	RadiusNorthM    float64
+	RadiusEastM     float64
+	BaseAltitudeM   float64
+	Metadata        map[string]interface{}
+}
+
+type gridSlot struct {
+	NorthM float64
+	EastM  float64
+	Row    int
+	Col    int
+}
+
+type createdTrack struct {
+	ID   string
+	Spec trafficTrackSpec
+}
+
+// TrackTrafficSimulation creates a spread-out set of tracks with different movement patterns.
+type TrackTrafficSimulation struct {
+	config      *Config
+	tracks      []createdTrack
+	startTime   time.Time
+	stopChan    chan struct{}
+	stopOnce    sync.Once
+	cleanupOnce sync.Once
+	mu          sync.Mutex
+}
+
+// NewTrackTrafficSimulation creates a new instance of the track traffic simulation.
+func NewTrackTrafficSimulation() simulation.Simulation {
+	return &TrackTrafficSimulation{
+		tracks:   make([]createdTrack, 0),
+		stopChan: make(chan struct{}),
+	}
+}
+
+func (s *TrackTrafficSimulation) Name() string {
+	return "Track Traffic Demo"
+}
+
+func (s *TrackTrafficSimulation) Description() string {
+	return "Creates smooth moving tracks with pre-seeded history for map playback testing"
+}
+
+func (s *TrackTrafficSimulation) Configure(params map[string]interface{}) error {
+	cfg, err := ValidateAndParse(params)
+	if err != nil {
+		return fmt.Errorf("configuration error: %w", err)
+	}
+
+	s.config = cfg
+	return nil
+}
+
+func (s *TrackTrafficSimulation) Run(ctx context.Context, legionClient *client.Legion) error {
+	if s.config == nil {
+		return fmt.Errorf("simulation not configured")
+	}
+
+	ctx = client.WithOrgID(ctx, s.config.OrganizationID)
+	s.startTime = time.Now().UTC()
+	defer s.cleanupTracks(legionClient)
+
+	specs := s.defaultTrackSpecs()
+	logger.Infof("Starting %s with %d tracks (max concurrency %d)", s.Name(), len(specs), s.config.MaxConcurrency)
+
+	if err := s.createTracksConcurrently(ctx, legionClient, specs); err != nil {
+		return fmt.Errorf("failed to create tracks: %w", err)
+	}
+
+	if err := s.seedHistory(ctx, legionClient, s.startTime); err != nil {
+		return fmt.Errorf("failed to seed historical track locations: %w", err)
+	}
+
+	if err := s.appendCurrentLocations(ctx, legionClient, s.startTime); err != nil {
+		return fmt.Errorf("failed to write initial track locations: %w", err)
+	}
+
+	ticker := time.NewTicker(s.config.UpdateInterval)
+	defer ticker.Stop()
+
+	timeout := time.After(s.config.Duration)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
+			return ctx.Err()
+		case <-s.stopChan:
+			logger.Info("Simulation stopped by user")
+			return nil
+		case <-timeout:
+			logger.Infof("Simulation completed after %s", s.config.Duration)
+			return nil
+		case tickTime := <-ticker.C:
+			if err := s.appendCurrentLocations(ctx, legionClient, tickTime.UTC()); err != nil {
+				logger.Errorf("Failed to append track locations: %v", err)
+			}
+		}
+	}
+}
+
+func (s *TrackTrafficSimulation) Stop() error {
+	s.stopOnce.Do(func() {
+		close(s.stopChan)
+	})
+	return nil
+}
+
+func (s *TrackTrafficSimulation) createTrack(ctx context.Context, legionClient *client.Legion, spec trafficTrackSpec) (string, error) {
+	orgUUID, err := uuid.Parse(s.config.OrganizationID)
+	if err != nil {
+		return "", fmt.Errorf("invalid organization ID: %w", err)
+	}
+
+	metadataJSON, err := json.Marshal(spec.Metadata)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	metadataRaw := json.RawMessage(metadataJSON)
+	name := spec.Name
+	entityType := spec.Type
+	status := spec.Status
+	category := models.CategoryTRACK
+
+	req := &models.CreateEntityRequest{
+		Affiliation:    spec.Affiliation,
+		Category:       &category,
+		Metadata:       &metadataRaw,
+		Name:           &name,
+		OrganizationID: &orgUUID,
+		Status:         &status,
+		Type:           &entityType,
+	}
+
+	created, err := legionClient.CreateEntity(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	logger.Infof("Created track entity %s (%s)", spec.Name, created.ID)
+	return created.ID.String(), nil
+}
+
+func (s *TrackTrafficSimulation) createTracksConcurrently(ctx context.Context, legionClient *client.Legion, specs []trafficTrackSpec) error {
+	results := make([]createdTrack, len(specs))
+
+	err := s.runBounded(ctx, len(specs), func(index int) error {
+		trackID, createErr := s.createTrack(ctx, legionClient, specs[index])
+		if createErr != nil {
+			return fmt.Errorf("%s: %w", specs[index].Name, createErr)
+		}
+		results[index] = createdTrack{ID: trackID, Spec: specs[index]}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.tracks = append(s.tracks[:0], results...)
+	s.mu.Unlock()
+
+	return nil
+}
+
+func (s *TrackTrafficSimulation) seedHistory(ctx context.Context, legionClient *client.Legion, now time.Time) error {
+	tracks := s.snapshotTracks()
+
+	return s.runBounded(ctx, len(tracks), func(index int) error {
+		track := tracks[index]
+		for i := s.config.HistoryPoints; i >= 1; i-- {
+			recordedAt := now.Add(-time.Duration(i) * s.config.HistoryStep)
+			location := s.buildTrackLocation(track.Spec, recordedAt)
+			if _, err := legionClient.CreateEntityLocation(ctx, track.ID, location); err != nil {
+				return fmt.Errorf("track %s: %w", track.Spec.Name, err)
+			}
+		}
+		return nil
+	})
+}
+
+func (s *TrackTrafficSimulation) appendCurrentLocations(ctx context.Context, legionClient *client.Legion, recordedAt time.Time) error {
+	tracks := s.snapshotTracks()
+	return s.runBounded(ctx, len(tracks), func(index int) error {
+		track := tracks[index]
+		req := s.buildTrackLocation(track.Spec, recordedAt)
+		if _, err := legionClient.CreateEntityLocation(ctx, track.ID, req); err != nil {
+			return fmt.Errorf("track %s: %w", track.Spec.Name, err)
+		}
+		return nil
+	})
+}
+
+func (s *TrackTrafficSimulation) cleanupTracks(legionClient *client.Legion) {
+	if !s.config.DeleteOnExit {
+		return
+	}
+
+	s.cleanupOnce.Do(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cleanupCtx = client.WithOrgID(cleanupCtx, s.config.OrganizationID)
+
+		tracks := s.snapshotTracks()
+		if err := s.runBounded(cleanupCtx, len(tracks), func(index int) error {
+			track := tracks[index]
+			if err := legionClient.DeleteEntity(cleanupCtx, track.ID); err != nil {
+				logger.Warnf("Failed to delete track %s (%s): %v", track.Spec.Name, track.ID, err)
+				return nil
+			}
+			logger.Infof("Deleted track %s (%s)", track.Spec.Name, track.ID)
+			return nil
+		}); err != nil {
+			logger.Warnf("Cleanup encountered an error: %v", err)
+		}
+	})
+}
+
+func (s *TrackTrafficSimulation) snapshotTracks() []createdTrack {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tracks := make([]createdTrack, len(s.tracks))
+	copy(tracks, s.tracks)
+	return tracks
+}
+
+func (s *TrackTrafficSimulation) buildTrackLocation(spec trafficTrackSpec, recordedAt time.Time) *models.CreateEntityLocationRequest {
+	elapsed := recordedAt.Sub(s.startTime).Seconds()
+	offsetNorth, offsetEast, altOffset := routeOffsets(spec, elapsed)
+	lat, lon := offsetLatLon(
+		s.config.CenterLat,
+		s.config.CenterLon,
+		spec.AnchorNorthM+offsetNorth,
+		spec.AnchorEastM+offsetEast,
+	)
+	alt := s.config.CenterAltMeters + spec.BaseAltitudeM + altOffset
+
+	x, y, z := latLonAltToECEF(lat, lon, alt)
+	pointType := "Point"
+
+	return &models.CreateEntityLocationRequest{
+		Position: &models.GeomPoint{
+			Type:        &pointType,
+			Coordinates: []float64{x, y, z},
+		},
+		Source:     spec.Source,
+		RecordedAt: &recordedAt,
+	}
+}
+
+func (s *TrackTrafficSimulation) defaultTrackSpecs() []trafficTrackSpec {
+	templates := s.baseTrackTemplates()
+	slots := jitteredGridSlots(s.config.TotalTracks, s.config.GridSpacingM, s.config.GridJitterM)
+	specs := make([]trafficTrackSpec, 0, s.config.TotalTracks)
+
+	for i := 0; i < s.config.TotalTracks; i++ {
+		template := templates[i%len(templates)]
+		slot := slots[i]
+		spec := trafficTrackSpec{
+			Name:            fmt.Sprintf("%s %03d", template.NamePrefix, i+1),
+			Type:            template.Type,
+			Status:          template.Status,
+			Affiliation:     template.Affiliation,
+			Source:          template.Source,
+			Pattern:         template.Pattern,
+			SpeedMetersPerS: template.SpeedMetersPerS,
+			AnchorNorthM:    slot.NorthM,
+			AnchorEastM:     slot.EastM,
+			RadiusNorthM:    template.RadiusNorthM,
+			RadiusEastM:     template.RadiusEastM,
+			BaseAltitudeM:   template.BaseAltitudeM,
+			Metadata:        cloneMetadata(template.Metadata),
+		}
+		spec.Metadata["instance_index"] = i + 1
+		spec.Metadata["grid_row"] = slot.Row
+		spec.Metadata["grid_col"] = slot.Col
+		specs = append(specs, spec)
+	}
+
+	return specs
+}
+
+func (s *TrackTrafficSimulation) baseTrackTemplates() []trackTemplate {
+	return []trackTemplate{
+		{
+			NamePrefix:      "Track Demo Quadcopter",
+			Type:            "UAS",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeCircle,
+			SpeedMetersPerS: 15,
+			RadiusNorthM:    90,
+			RadiusEastM:     90,
+			BaseAltitudeM:   80,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "small-uas",
+				"display_speed_mps":  15,
+				"movement_pattern":   "circle",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo VTOL",
+			Type:            "UAS",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeFigure8,
+			SpeedMetersPerS: 28,
+			RadiusNorthM:    120,
+			RadiusEastM:     75,
+			BaseAltitudeM:   120,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "vtol",
+				"display_speed_mps":  28,
+				"movement_pattern":   "figure8",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo Fixed Wing",
+			Type:            "UAS",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeEllipse,
+			SpeedMetersPerS: 55,
+			RadiusNorthM:    180,
+			RadiusEastM:     110,
+			BaseAltitudeM:   450,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "fixed-wing",
+				"display_speed_mps":  55,
+				"movement_pattern":   "ellipse",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo Fast Mover",
+			Type:            "UAS",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeLissajous,
+			SpeedMetersPerS: 120,
+			RadiusNorthM:    220,
+			RadiusEastM:     140,
+			BaseAltitudeM:   900,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "high-speed-fixed-wing",
+				"display_speed_mps":  120,
+				"movement_pattern":   "lissajous",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo Walker",
+			Type:            "Human",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeWalker,
+			SpeedMetersPerS: 5.0 / 3.6,
+			RadiusNorthM:    30,
+			RadiusEastM:     18,
+			BaseAltitudeM:   2,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "walking-human",
+				"display_speed_kph":  5,
+				"movement_pattern":   "walking-loop",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo Pedestrian",
+			Type:            "Human",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeFigure8,
+			SpeedMetersPerS: 4.6 / 3.6,
+			RadiusNorthM:    24,
+			RadiusEastM:     16,
+			BaseAltitudeM:   2,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "walking-human",
+				"display_speed_kph":  4.6,
+				"movement_pattern":   "figure8-walk",
+				"historical_enabled": true,
+			},
+		},
+		{
+			NamePrefix:      "Track Demo Camera Jitter",
+			Type:            "Camera",
+			Status:          "ACTIVE",
+			Affiliation:     models.AffiliationFRIEND,
+			Source:          "Track-Traffic-Sim",
+			Pattern:         routeJitter,
+			SpeedMetersPerS: 0,
+			RadiusNorthM:    10,
+			RadiusEastM:     10,
+			BaseAltitudeM:   8,
+			Metadata: map[string]interface{}{
+				"sim":                "track-traffic",
+				"profile":            "stationary-camera",
+				"actual_motion":      "stationary",
+				"movement_pattern":   "gps-jitter",
+				"jitter_radius_m":    10,
+				"historical_enabled": true,
+			},
+		},
+	}
+}
+
+func routeOffsets(spec trafficTrackSpec, elapsedSeconds float64) (northM, eastM, altM float64) {
+	switch spec.Pattern {
+	case routeCircle:
+		period := loopPeriod(spec.SpeedMetersPerS, spec.RadiusNorthM, spec.RadiusEastM)
+		theta := 2 * math.Pi * elapsedSeconds / period
+		return spec.RadiusNorthM * math.Cos(theta), spec.RadiusEastM * math.Sin(theta), 8 * math.Sin(theta*0.5)
+	case routeEllipse:
+		period := loopPeriod(spec.SpeedMetersPerS, spec.RadiusNorthM, spec.RadiusEastM)
+		theta := 2 * math.Pi * elapsedSeconds / period
+		return spec.RadiusNorthM * math.Cos(theta), spec.RadiusEastM * math.Sin(theta), 25 * math.Sin(theta*0.7)
+	case routeFigure8:
+		period := loopPeriod(maxFloat(spec.SpeedMetersPerS, 0.5), maxFloat(spec.RadiusNorthM, 10), maxFloat(spec.RadiusEastM, 10))
+		theta := 2 * math.Pi * elapsedSeconds / period
+		return spec.RadiusNorthM * math.Sin(theta), spec.RadiusEastM * math.Sin(theta) * math.Cos(theta), 5 * math.Sin(theta*2)
+	case routeLissajous:
+		period := loopPeriod(maxFloat(spec.SpeedMetersPerS, 0.5), maxFloat(spec.RadiusNorthM, 10), maxFloat(spec.RadiusEastM, 10))
+		theta := 2 * math.Pi * elapsedSeconds / period
+		return spec.RadiusNorthM * math.Sin(theta), spec.RadiusEastM * math.Sin(2*theta+math.Pi/3), 40 * math.Sin(theta*1.5)
+	case routeWalker:
+		period := loopPeriod(maxFloat(spec.SpeedMetersPerS, 0.1), maxFloat(spec.RadiusNorthM, 5), maxFloat(spec.RadiusEastM, 5))
+		theta := 2 * math.Pi * elapsedSeconds / period
+		return spec.RadiusNorthM * math.Sin(theta), spec.RadiusEastM * math.Sin(theta*0.5), 0
+	case routeJitter:
+		north := spec.RadiusNorthM * (0.55*math.Sin(elapsedSeconds/5.0) + 0.25*math.Sin(elapsedSeconds/1.7+1.2) + 0.2*math.Sin(elapsedSeconds/0.8+2.4))
+		east := spec.RadiusEastM * (0.5*math.Sin(elapsedSeconds/4.2+0.3) + 0.3*math.Sin(elapsedSeconds/1.3+2.0) + 0.2*math.Sin(elapsedSeconds/0.7+0.9))
+		return north, east, 0
+	default:
+		return 0, 0, 0
+	}
+}
+
+func loopPeriod(speedMetersPerS, radiusNorthM, radiusEastM float64) float64 {
+	circumference := 2 * math.Pi * math.Sqrt((radiusNorthM*radiusNorthM+radiusEastM*radiusEastM)/2)
+	return maxFloat(circumference/maxFloat(speedMetersPerS, 0.5), 5)
+}
+
+func offsetLatLon(baseLat, baseLon, northM, eastM float64) (float64, float64) {
+	metersPerDegLat := 111111.0
+	metersPerDegLon := 111111.0 * math.Cos(baseLat*math.Pi/180.0)
+	if math.Abs(metersPerDegLon) < 1 {
+		metersPerDegLon = 1
+	}
+
+	lat := baseLat + northM/metersPerDegLat
+	lon := baseLon + eastM/metersPerDegLon
+	return lat, lon
+}
+
+func latLonAltToECEF(lat, lon, alt float64) (x, y, z float64) {
+	a := 6378137.0
+	f := 1.0 / 298.257223563
+	e2 := 2*f - f*f
+
+	latRad := lat * math.Pi / 180.0
+	lonRad := lon * math.Pi / 180.0
+
+	sinLat := math.Sin(latRad)
+	n := a / math.Sqrt(1-e2*sinLat*sinLat)
+
+	x = (n + alt) * math.Cos(latRad) * math.Cos(lonRad)
+	y = (n + alt) * math.Cos(latRad) * math.Sin(lonRad)
+	z = (n*(1-e2) + alt) * math.Sin(latRad)
+	return x, y, z
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func jitteredGridSlots(totalTracks int, gridSpacingM, gridJitterM float64) []gridSlot {
+	cols := int(math.Ceil(math.Sqrt(float64(totalTracks))))
+	rows := int(math.Ceil(float64(totalTracks) / float64(cols)))
+	slots := make([]gridSlot, 0, totalTracks)
+
+	for idx := 0; idx < totalTracks; idx++ {
+		row := idx / cols
+		col := idx % cols
+
+		north := (float64(row) - float64(rows-1)/2.0) * gridSpacingM
+		east := (float64(col) - float64(cols-1)/2.0) * gridSpacingM
+		if row%2 == 1 {
+			east += gridSpacingM * 0.18
+		}
+
+		north += gridJitterM * deterministicSpread(idx, 1)
+		east += gridJitterM * deterministicSpread(idx, 2)
+
+		slots = append(slots, gridSlot{
+			NorthM: north,
+			EastM:  east,
+			Row:    row,
+			Col:    col,
+		})
+	}
+
+	return slots
+}
+
+func deterministicSpread(index, salt int) float64 {
+	value := math.Sin(float64((index+1)*(salt*97+37))) * 43758.5453123
+	fraction := value - math.Floor(value)
+	return fraction*2 - 1
+}
+
+func cloneMetadata(metadata map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func (s *TrackTrafficSimulation) runBounded(ctx context.Context, itemCount int, fn func(index int) error) error {
+	if itemCount == 0 {
+		return nil
+	}
+
+	workerCount := minInt(itemCount, maxInt(s.config.MaxConcurrency, 1))
+	jobs := make(chan int)
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	worker := func() {
+		defer wg.Done()
+		for index := range jobs {
+			if err := fn(index); err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+			}
+		}
+	}
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+sendLoop:
+	for index := 0; index < itemCount; index++ {
+		select {
+		case <-ctx.Done():
+			break sendLoop
+		case err := <-errCh:
+			close(jobs)
+			wg.Wait()
+			return err
+		case jobs <- index:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+
+	return ctx.Err()
+}
+
+func init() {
+	if err := simulation.DefaultRegistry.Register("Track Traffic Demo", NewTrackTrafficSimulation); err != nil {
+		logger.Errorf("Failed to register simulation: %v", err)
+	}
+}

--- a/cmd/track-traffic/simulation.yaml
+++ b/cmd/track-traffic/simulation.yaml
@@ -1,0 +1,90 @@
+name: "Track Traffic Demo"
+description: "Spread out multiple tracks with smooth routes and seeded history for frontend map testing"
+version: "1.0.0"
+category: "demo"
+
+parameters:
+  - name: "total_tracks"
+    type: "integer"
+    description: "Total number of tracks to create for map testing or load testing"
+    default: 7
+    min: 1
+    required: true
+
+  - name: "max_concurrency"
+    type: "integer"
+    description: "Maximum number of concurrent API operations used for create, seed, update, and cleanup"
+    default: 8
+    min: 1
+    required: false
+
+  - name: "update_interval"
+    type: "float"
+    description: "How often to append a new live track location (seconds)"
+    default: 2.0
+    min: 1.0
+    max: 60.0
+    required: true
+
+  - name: "duration"
+    type: "duration"
+    description: "How long to run the simulation"
+    default: "5m"
+    required: true
+
+  - name: "center_lat"
+    type: "float"
+    description: "Center latitude for the overall layout"
+    default: 37.7749
+    required: true
+
+  - name: "center_lon"
+    type: "float"
+    description: "Center longitude for the overall layout"
+    default: -122.4194
+    required: true
+
+  - name: "center_alt_m"
+    type: "float"
+    description: "Base altitude offset for the scene (meters)"
+    default: 0.0
+    required: true
+
+  - name: "grid_spacing_m"
+    type: "float"
+    description: "Base spacing between tracks in the jittered grid layout"
+    default: 700.0
+    min: 100.0
+    required: true
+
+  - name: "grid_jitter_m"
+    type: "float"
+    description: "Random offset applied to each grid slot so the layout feels less rigid"
+    default: 80.0
+    min: 0.0
+    required: true
+
+  - name: "history_points"
+    type: "integer"
+    description: "How many historical points to seed per track before live updates start"
+    default: 36
+    min: 2
+    required: true
+
+  - name: "history_step_seconds"
+    type: "float"
+    description: "Spacing between seeded historical points (seconds)"
+    default: 5.0
+    min: 1.0
+    required: true
+
+  - name: "delete_on_exit"
+    type: "boolean"
+    description: "Delete all created tracks and their history when the simulation ends"
+    default: true
+    required: false
+
+  - name: "organization_id"
+    type: "string"
+    description: "Organization ID for track creation"
+    required: true


### PR DESCRIPTION
## Summary
- add a new Track Traffic Demo simulation with seeded history and smooth movement patterns
- register the new simulation in the CLI run command
- include validation coverage for the new simulation config


https://github.com/user-attachments/assets/465609da-2f0c-46cc-b400-6726f45ec89f



## Context
This stacks the new track-traffic simulation on top of the OpenAPI 3 migration so review stays focused on the simulation behavior and CLI wiring.

## Testing
- go test ./cmd/track-traffic
- go test ./...

## Issues
- None