### PR TITLE
ci(security): SHA-pin GitHub Actions to commit digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    # Grouped so all action bumps land in one PR per week, never one-per-action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set Up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           args: --timeout=30m --config=./.golangci.yaml --issues-exit-code=0
           version: v2.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,15 +10,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set Up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
 
       - name: Cache Go Modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/go/pkg/mod
@@ -32,13 +32,13 @@ jobs:
 
       - name: Upload Test Results
         if: always() # Always run this step to upload results, even if tests fail
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unit-test-results
           path: unit-results.json
 
       - name: Post Test Summary
         if: always() # Always run this step to post summary
-        uses: robherley/go-test-action@v0
+        uses: robherley/go-test-action@42a1975c97156330b5126c2f35ef0fb78c4c7154 # v0.7.1
         with:
           fromJSONFile: unit-results.json


### PR DESCRIPTION
Pins every third-party action to a full commit SHA (with a version comment), resolved with `pinact`. Closes the tag-mutability supply-chain gap (a tag like `@v4` can be silently repointed). `pinact` resolves each tag to the commit it currently points at, so there is no version or behavior change. Part of the org-wide DevSecOps hardening rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use fixed versions for checkout, Go setup, linting, caching, artifact uploads, and test reporting.
  * Existing linting, testing, caching, artifact upload, and test-summary behavior remains unchanged.
  * Added weekly Dependabot checks for GitHub Actions, grouping updates into a single pull request with a limit of five open requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->